### PR TITLE
Fix: Improve XHR error handling to prevent 'undefined' link

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -121,7 +121,28 @@ const uploadFile = () => {
 
   xhr.onreadystatechange = function () {
     if (xhr.readyState == XMLHttpRequest.DONE) {
-      onFileUploadSuccess(xhr.responseText);
+      if (xhr.status === 200) {
+        onFileUploadSuccess(xhr.responseText);
+      } else {
+        let errorMessage = `Error processing file: ${xhr.status} ${xhr.statusText}`;
+        try {
+          const errorResponse = JSON.parse(xhr.responseText);
+          if (errorResponse && errorResponse.error) {
+            errorMessage = errorResponse.error;
+          }
+        } catch (e) {
+          // Response was not JSON or no 'error' property, use default message
+          console.error("Could not parse error response as JSON:", e);
+        }
+        showToast(errorMessage);
+        // Reset UI
+        uploadView.style.display = "block";
+        progressView.style.display = "none";
+        postUploadView.style.display = "none";
+        if (fileInput) {
+          fileInput.value = ""; // Clear the file input
+        }
+      }
     }
   };
 


### PR DESCRIPTION
Previously, the XHR `onreadystatechange` handler in `public/js/app.js` did not check the `xhr.status` before calling `onFileUploadSuccess`. This meant that if the server returned an error response (e.g., a 500 error due to a misconfigured encryption key, or a 400 error if no file was attached), the `onFileUploadSuccess` function would still be called with the error page content. Attempting to parse this as JSON would lead to `url` being undefined, which then caused "undefined" to be copied when you tried to get the file link.

This commit updates the `xhr.onreadystatechange` handler to:
1.  Check if `xhr.status` is 200 before calling `onFileUploadSuccess`.
2.  If the status is not 200, display an error message via `showToast()`. The message attempts to parse a JSON error from `xhr.responseText` (e.g., `{"error": "message"}`) or defaults to a generic `Error processing file: <status> <statusText>`.
3.  Reset the UI (upload view, progress view, file input) to allow you to attempt another upload.

This ensures that server-side errors are gracefully handled on the client-side, providing better feedback to you and preventing the 'undefined' link issue.